### PR TITLE
feat(ui): replace native select menus

### DIFF
--- a/src/components/AppSelect.tsx
+++ b/src/components/AppSelect.tsx
@@ -4,8 +4,10 @@ import {
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
   type KeyboardEvent,
 } from 'react';
+import { createPortal } from 'react-dom';
 import { Check, ChevronDown } from 'lucide-react';
 
 export type AppSelectOption = {
@@ -48,7 +50,9 @@ export function AppSelect({
   const [open, setOpen] = useState(false);
   const [openUpward, setOpenUpward] = useState(false);
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const [menuStyle, setMenuStyle] = useState<CSSProperties>({});
   const rootRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
   const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const listboxId = useId();
   const selectedIndex = useMemo(
@@ -58,12 +62,39 @@ export function AppSelect({
   const selectedOption = selectedIndex >= 0 ? options[selectedIndex] : undefined;
   const selectedLabel = selectedOption?.label ?? value;
 
+  const updatePlacement = () => {
+    const bounds = rootRef.current?.getBoundingClientRect();
+    if (!bounds) return;
+    const viewportPadding = 12;
+    const menuGap = 6;
+    const spaceBelow = window.innerHeight - bounds.bottom - viewportPadding;
+    const spaceAbove = bounds.top - viewportPadding;
+    const upward = spaceBelow < 250 && spaceAbove > spaceBelow;
+    const availableHeight = Math.max(96, (upward ? spaceAbove : spaceBelow) - menuGap);
+    const width = Math.min(bounds.width, window.innerWidth - viewportPadding * 2);
+    const left = Math.min(
+      Math.max(viewportPadding, bounds.left),
+      Math.max(viewportPadding, window.innerWidth - viewportPadding - width),
+    );
+
+    setOpenUpward(upward);
+    setMenuStyle({
+      left,
+      width,
+      maxHeight: Math.min(280, availableHeight),
+      ...(upward
+        ? { top: 'auto', bottom: window.innerHeight - bounds.top + menuGap }
+        : { top: bounds.bottom + menuGap, bottom: 'auto' }),
+    });
+  };
+
   const openMenu = () => {
     if (disabled || options.length === 0) return;
     const initialIndex = selectedIndex >= 0 && !options[selectedIndex]?.disabled
       ? selectedIndex
       : nextEnabledOptionIndex(options, -1, 1);
     setHighlightedIndex(initialIndex);
+    updatePlacement();
     setOpen(true);
   };
 
@@ -116,13 +147,8 @@ export function AppSelect({
     if (!open) return;
 
     const closeOnOutsideClick = (event: PointerEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) closeMenu();
-    };
-    const updatePlacement = () => {
-      const bounds = rootRef.current?.getBoundingClientRect();
-      if (!bounds) return;
-      const spaceBelow = window.innerHeight - bounds.bottom;
-      setOpenUpward(spaceBelow < 250 && bounds.top > spaceBelow);
+      const target = event.target as Node;
+      if (!rootRef.current?.contains(target) && !menuRef.current?.contains(target)) closeMenu();
     };
 
     updatePlacement();
@@ -134,7 +160,7 @@ export function AppSelect({
       window.removeEventListener('resize', updatePlacement);
       window.removeEventListener('scroll', updatePlacement, true);
     };
-  }, [open]);
+  }, [open, options.length]);
 
   useEffect(() => {
     if (open && highlightedIndex >= 0) {
@@ -166,8 +192,15 @@ export function AppSelect({
         <span className="app-select-value" title={selectedLabel}>{selectedLabel}</span>
         <ChevronDown size={15} aria-hidden="true" />
       </button>
-      {open ? (
-        <div className="app-select-menu" id={listboxId} role="listbox" aria-label={ariaLabel}>
+      {open && typeof document !== 'undefined' ? createPortal(
+        <div
+          ref={menuRef}
+          className={`app-select-menu ${openUpward ? 'open-upward' : ''}`}
+          id={listboxId}
+          role="listbox"
+          aria-label={ariaLabel}
+          style={menuStyle}
+        >
           {options.map((option, index) => (
             <button
               key={`${option.value}-${index}`}
@@ -186,7 +219,8 @@ export function AppSelect({
               {option.value === value ? <Check size={15} aria-hidden="true" /> : null}
             </button>
           ))}
-        </div>
+        </div>,
+        document.body,
       ) : null}
     </div>
   );

--- a/src/components/AppSelect.tsx
+++ b/src/components/AppSelect.tsx
@@ -1,0 +1,193 @@
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from 'react';
+import { Check, ChevronDown } from 'lucide-react';
+
+export type AppSelectOption = {
+  value: string;
+  label: string;
+  disabled?: boolean;
+};
+
+type AppSelectProps = {
+  value: string;
+  options: AppSelectOption[];
+  onChange: (value: string) => void;
+  ariaLabel: string;
+  className?: string;
+  disabled?: boolean;
+};
+
+export const nextEnabledOptionIndex = (
+  options: AppSelectOption[],
+  currentIndex: number,
+  direction: 1 | -1,
+) => {
+  if (options.length === 0) return -1;
+  const start = currentIndex >= 0 ? currentIndex : direction === 1 ? -1 : 0;
+  for (let offset = 1; offset <= options.length; offset += 1) {
+    const index = (start + direction * offset + options.length) % options.length;
+    if (!options[index]?.disabled) return index;
+  }
+  return -1;
+};
+
+export function AppSelect({
+  value,
+  options,
+  onChange,
+  ariaLabel,
+  className = '',
+  disabled = false,
+}: AppSelectProps) {
+  const [open, setOpen] = useState(false);
+  const [openUpward, setOpenUpward] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const listboxId = useId();
+  const selectedIndex = useMemo(
+    () => options.findIndex((option) => option.value === value),
+    [options, value],
+  );
+  const selectedOption = selectedIndex >= 0 ? options[selectedIndex] : undefined;
+  const selectedLabel = selectedOption?.label ?? value;
+
+  const openMenu = () => {
+    if (disabled || options.length === 0) return;
+    const initialIndex = selectedIndex >= 0 && !options[selectedIndex]?.disabled
+      ? selectedIndex
+      : nextEnabledOptionIndex(options, -1, 1);
+    setHighlightedIndex(initialIndex);
+    setOpen(true);
+  };
+
+  const closeMenu = () => setOpen(false);
+
+  const selectOption = (index: number) => {
+    const option = options[index];
+    if (!option || option.disabled) return;
+    if (option.value !== value) onChange(option.value);
+    closeMenu();
+  };
+
+  const onTriggerKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (disabled) return;
+    if (event.key === 'Escape' && open) {
+      event.preventDefault();
+      closeMenu();
+      return;
+    }
+    if (event.key === 'Tab') {
+      closeMenu();
+      return;
+    }
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      if (!open) {
+        openMenu();
+        return;
+      }
+      const direction = event.key === 'ArrowDown' ? 1 : -1;
+      setHighlightedIndex((current) => nextEnabledOptionIndex(options, current, direction));
+      return;
+    }
+    if (open && (event.key === 'Home' || event.key === 'End')) {
+      event.preventDefault();
+      const index = event.key === 'Home'
+        ? nextEnabledOptionIndex(options, -1, 1)
+        : nextEnabledOptionIndex(options, 0, -1);
+      setHighlightedIndex(index);
+      return;
+    }
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      if (open) selectOption(highlightedIndex);
+      else openMenu();
+    }
+  };
+
+  useEffect(() => {
+    if (!open) return;
+
+    const closeOnOutsideClick = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) closeMenu();
+    };
+    const updatePlacement = () => {
+      const bounds = rootRef.current?.getBoundingClientRect();
+      if (!bounds) return;
+      const spaceBelow = window.innerHeight - bounds.bottom;
+      setOpenUpward(spaceBelow < 250 && bounds.top > spaceBelow);
+    };
+
+    updatePlacement();
+    document.addEventListener('pointerdown', closeOnOutsideClick);
+    window.addEventListener('resize', updatePlacement);
+    window.addEventListener('scroll', updatePlacement, true);
+    return () => {
+      document.removeEventListener('pointerdown', closeOnOutsideClick);
+      window.removeEventListener('resize', updatePlacement);
+      window.removeEventListener('scroll', updatePlacement, true);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (open && highlightedIndex >= 0) {
+      optionRefs.current[highlightedIndex]?.scrollIntoView({ block: 'nearest' });
+    }
+  }, [highlightedIndex, open]);
+
+  useEffect(() => {
+    if (disabled) closeMenu();
+  }, [disabled]);
+
+  return (
+    <div
+      ref={rootRef}
+      className={`app-select ${open ? 'open' : ''} ${openUpward ? 'open-upward' : ''} ${className}`.trim()}
+    >
+      <button
+        type="button"
+        className="app-select-trigger"
+        disabled={disabled}
+        aria-label={ariaLabel}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        aria-activedescendant={open && highlightedIndex >= 0 ? `${listboxId}-option-${highlightedIndex}` : undefined}
+        onClick={() => open ? closeMenu() : openMenu()}
+        onKeyDown={onTriggerKeyDown}
+      >
+        <span className="app-select-value" title={selectedLabel}>{selectedLabel}</span>
+        <ChevronDown size={15} aria-hidden="true" />
+      </button>
+      {open ? (
+        <div className="app-select-menu" id={listboxId} role="listbox" aria-label={ariaLabel}>
+          {options.map((option, index) => (
+            <button
+              key={`${option.value}-${index}`}
+              ref={(element) => { optionRefs.current[index] = element; }}
+              id={`${listboxId}-option-${index}`}
+              type="button"
+              role="option"
+              tabIndex={-1}
+              disabled={option.disabled}
+              aria-selected={option.value === value}
+              className={`app-select-option ${index === highlightedIndex ? 'highlighted' : ''} ${option.value === value ? 'selected' : ''}`.trim()}
+              onMouseEnter={() => !option.disabled && setHighlightedIndex(index)}
+              onClick={() => selectOption(index)}
+            >
+              <span title={option.label}>{option.label}</span>
+              {option.value === value ? <Check size={15} aria-hidden="true" /> : null}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/pages/ApiAccessPage.tsx
+++ b/src/pages/ApiAccessPage.tsx
@@ -16,6 +16,7 @@ import codexIcon from '../assets/icons/codex.svg';
 import deepseekIcon from '../assets/icons/deepseek.svg';
 import geminiIcon from '../assets/icons/gemini.svg';
 import openaiIcon from '../assets/icons/openai-light.svg';
+import { AppSelect } from '../components/AppSelect';
 import {
   isRecord,
   managementApi,
@@ -1687,12 +1688,17 @@ function ApiProviderDialog({
               <div className="provider-cloak-settings">
                 <label>
                   <span>{t('apiAccess.cloak.mode')}</span>
-                  <select value={draft.cloakMode ?? ''} onChange={(event) => updateTextField('cloakMode', event.currentTarget.value)}>
-                    <option value="">{t('apiAccess.cloak.default')}</option>
-                    <option value="auto">Auto</option>
-                    <option value="always">Always</option>
-                    <option value="never">Never</option>
-                  </select>
+                  <AppSelect
+                    value={draft.cloakMode ?? ''}
+                    onChange={(value) => updateTextField('cloakMode', value)}
+                    ariaLabel={t('apiAccess.cloak.mode')}
+                    options={[
+                      { value: '', label: t('apiAccess.cloak.default') },
+                      { value: 'auto', label: 'Auto' },
+                      { value: 'always', label: 'Always' },
+                      { value: 'never', label: 'Never' },
+                    ]}
+                  />
                 </label>
                 <label className="multiline-field">
                   <span>{t('apiAccess.cloak.words')}</span>

--- a/src/pages/AuthFileManagementPage.tsx
+++ b/src/pages/AuthFileManagementPage.tsx
@@ -19,6 +19,7 @@ import geminiIcon from '../assets/icons/gemini.svg';
 import grokIcon from '../assets/icons/grok.svg';
 import kimiIcon from '../assets/icons/kimi-light.svg';
 import vertexIcon from '../assets/icons/vertex.svg';
+import { AppSelect } from '../components/AppSelect';
 import {
   formatDate,
   managementApi,
@@ -491,16 +492,26 @@ export function AuthFileManagementPage() {
         <div className="management-toolbar auth-files-toolbar">
           <Search size={16} />
           <input value={filter} onChange={(event) => setFilter(event.currentTarget.value)} placeholder={t('authFiles.searchPlaceholder')} />
-          <select value={providerFilter} onChange={(event) => setProviderFilter(event.currentTarget.value)}>
-            <option value="all">{t('authFiles.filter.allProviders')}</option>
-            {providers.map((provider) => <option key={provider} value={provider}>{provider}</option>)}
-          </select>
-          <select value={statusFilter} onChange={(event) => setStatusFilter(event.currentTarget.value as typeof statusFilter)}>
-            <option value="all">{t('authFiles.filter.allStatuses')}</option>
-            <option value="enabled">{t('authFiles.filter.enabled')}</option>
-            <option value="disabled">{t('authFiles.filter.disabled')}</option>
-            <option value="runtime">{t('authFiles.filter.runtime')}</option>
-          </select>
+          <AppSelect
+            value={providerFilter}
+            onChange={setProviderFilter}
+            ariaLabel={t('authFiles.filter.allProviders')}
+            options={[
+              { value: 'all', label: t('authFiles.filter.allProviders') },
+              ...providers.map((provider) => ({ value: provider, label: provider })),
+            ]}
+          />
+          <AppSelect
+            value={statusFilter}
+            onChange={(value) => setStatusFilter(value as typeof statusFilter)}
+            ariaLabel={t('authFiles.filter.allStatuses')}
+            options={[
+              { value: 'all', label: t('authFiles.filter.allStatuses') },
+              { value: 'enabled', label: t('authFiles.filter.enabled') },
+              { value: 'disabled', label: t('authFiles.filter.disabled') },
+              { value: 'runtime', label: t('authFiles.filter.runtime') },
+            ]}
+          />
         </div>
 
         {loading ? (

--- a/src/pages/ConfigPanel.tsx
+++ b/src/pages/ConfigPanel.tsx
@@ -22,6 +22,7 @@ import {
   X,
 } from 'lucide-react';
 import { useCoreRuntime, type CoreStatus } from '../coreRuntime';
+import { AppSelect } from '../components/AppSelect';
 import { useI18n } from '../i18n';
 import { webUiManagementUrl } from '../services/clientAccess';
 import { ThinkingAliasesPage } from './ThinkingAliasesPage';
@@ -1131,19 +1132,20 @@ export function ConfigPanelPage() {
                   </div>
                   <label className="config-software-select">
                     <span className="sr-only">{t('config.software.closeBehavior')}</span>
-                    <select
-                      className="config-network-input"
+                    <AppSelect
                       value={softwareCloseBehaviorDraft}
                       disabled={softwareSettingsLoading || softwareSettings === null || busyAction !== null}
-                      onChange={(event) => {
+                      ariaLabel={t('config.software.closeBehavior')}
+                      onChange={(value) => {
                         setSoftwareSavedStatusVisible(false);
-                        setSoftwareCloseBehaviorDraft(event.currentTarget.value as CloseBehavior);
+                        setSoftwareCloseBehaviorDraft(value as CloseBehavior);
                       }}
-                    >
-                      <option value="ask">{t('config.software.behavior.ask')}</option>
-                      <option value="minimize-to-tray">{t('config.software.behavior.minimize')}</option>
-                      <option value="exit">{t('config.software.behavior.exit')}</option>
-                    </select>
+                      options={[
+                        { value: 'ask', label: t('config.software.behavior.ask') },
+                        { value: 'minimize-to-tray', label: t('config.software.behavior.minimize') },
+                        { value: 'exit', label: t('config.software.behavior.exit') },
+                      ]}
+                    />
                   </label>
                 </div>
               </div>

--- a/src/pages/UsageRecordsPage.tsx
+++ b/src/pages/UsageRecordsPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { Activity, BarChart3, CircleDollarSign, Clock3, Database, List, Pencil, RefreshCw, ShieldCheck, Sparkles, Trash2, TriangleAlert, X } from 'lucide-react';
+import { AppSelect } from '../components/AppSelect';
 import { getCurrentLocale, useI18n } from '../i18n';
 import { formatUsageNumber } from '../services/usageNumber';
 
@@ -390,14 +391,25 @@ export function UsageRecordsPage() {
       </div>
 
       <section className="panel usage-filter-panel">
-        <select value={range} onChange={(event) => { setRange(event.currentTarget.value as UsageRange); setPage(1); }} aria-label={t('usage.filter.timeRange')}>
-          <option value="4h">{t('usage.range.4h')}</option><option value="24h">{t('usage.range.24h')}</option><option value="today">{t('usage.range.today')}</option><option value="7d">{t('usage.range.7d')}</option><option value="30d">{t('usage.range.30d')}</option><option value="all">{t('usage.range.all')}</option><option value="custom">{t('usage.range.custom')}</option>
-        </select>
-        <select value={model} onChange={(event) => changeFilter(setModel, event.currentTarget.value)} aria-label={t('usage.filter.model')}><option value="">{t('usage.filter.allModels')}</option>{filterOptions(optionsAnalysis.models).map((item) => <option value={item.key} key={item.key}>{item.label}</option>)}</select>
-        <select value={provider} onChange={(event) => changeFilter(setProvider, event.currentTarget.value)} aria-label="Provider"><option value="">{t('usage.filter.allProviders')}</option>{filterOptions(optionsAnalysis.providers).map((item) => <option value={item.key} key={item.key}>{item.label}</option>)}</select>
-        <select value={source} onChange={(event) => changeFilter(setSource, event.currentTarget.value)} aria-label={t('usage.filter.source')}><option value="">{t('usage.filter.allSources')}</option>{filterOptions(optionsAnalysis.sources).map((item) => <option value={item.key} key={item.key}>{item.label}</option>)}</select>
-        <select value={apiKeyHash} onChange={(event) => changeFilter(setApiKeyHash, event.currentTarget.value)} aria-label="API Key"><option value="">{t('usage.filter.allKeys')}</option>{filterOptions(optionsAnalysis.apiKeys).map((item) => <option value={item.key} key={item.key}>{item.label}</option>)}</select>
-        <select value={result} onChange={(event) => changeFilter(setResult, event.currentTarget.value)} aria-label={t('usage.filter.result')}><option value="all">{t('usage.filter.allResults')}</option><option value="success">{t('usage.result.success')}</option><option value="failed">{t('usage.result.failed')}</option></select>
+        <AppSelect
+          value={range}
+          onChange={(value) => { setRange(value as UsageRange); setPage(1); }}
+          ariaLabel={t('usage.filter.timeRange')}
+          options={[
+            { value: '4h', label: t('usage.range.4h') },
+            { value: '24h', label: t('usage.range.24h') },
+            { value: 'today', label: t('usage.range.today') },
+            { value: '7d', label: t('usage.range.7d') },
+            { value: '30d', label: t('usage.range.30d') },
+            { value: 'all', label: t('usage.range.all') },
+            { value: 'custom', label: t('usage.range.custom') },
+          ]}
+        />
+        <AppSelect value={model} onChange={(value) => changeFilter(setModel, value)} ariaLabel={t('usage.filter.model')} options={[{ value: '', label: t('usage.filter.allModels') }, ...filterOptions(optionsAnalysis.models).map((item) => ({ value: item.key, label: item.label }))]} />
+        <AppSelect value={provider} onChange={(value) => changeFilter(setProvider, value)} ariaLabel="Provider" options={[{ value: '', label: t('usage.filter.allProviders') }, ...filterOptions(optionsAnalysis.providers).map((item) => ({ value: item.key, label: item.label }))]} />
+        <AppSelect value={source} onChange={(value) => changeFilter(setSource, value)} ariaLabel={t('usage.filter.source')} options={[{ value: '', label: t('usage.filter.allSources') }, ...filterOptions(optionsAnalysis.sources).map((item) => ({ value: item.key, label: item.label }))]} />
+        <AppSelect value={apiKeyHash} onChange={(value) => changeFilter(setApiKeyHash, value)} ariaLabel="API Key" options={[{ value: '', label: t('usage.filter.allKeys') }, ...filterOptions(optionsAnalysis.apiKeys).map((item) => ({ value: item.key, label: item.label }))]} />
+        <AppSelect value={result} onChange={(value) => changeFilter(setResult, value)} ariaLabel={t('usage.filter.result')} options={[{ value: 'all', label: t('usage.filter.allResults') }, { value: 'success', label: t('usage.result.success') }, { value: 'failed', label: t('usage.result.failed') }]} />
         {range === 'custom' ? <div className="usage-custom-range"><input type="datetime-local" value={customStart} onChange={(event) => setCustomStart(event.currentTarget.value)} aria-label={t('usage.filter.startTime')} /><span>{t('usage.filter.to')}</span><input type="datetime-local" value={customEnd} onChange={(event) => setCustomEnd(event.currentTarget.value)} aria-label={t('usage.filter.endTime')} /></div> : null}
       </section>
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -490,15 +490,11 @@ textarea:focus-visible {
 }
 
 .app-select-menu {
-  position: absolute;
+  position: fixed;
   z-index: 120;
-  top: calc(100% + 6px);
-  left: 0;
   display: grid;
   gap: 2px;
-  width: 100%;
   min-width: 0;
-  max-height: min(280px, calc(100vh - 32px));
   overflow-x: hidden;
   overflow-y: auto;
   padding: 6px;
@@ -509,9 +505,7 @@ textarea:focus-visible {
   animation: app-select-menu-in 120ms ease-out;
 }
 
-.app-select.open-upward .app-select-menu {
-  top: auto;
-  bottom: calc(100% + 6px);
+.app-select-menu.open-upward {
   transform-origin: bottom;
 }
 
@@ -572,7 +566,7 @@ textarea:focus-visible {
   }
 }
 
-.app-select.open-upward .app-select-menu {
+.app-select-menu.open-upward {
   animation-name: app-select-menu-in-upward;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -433,6 +433,160 @@ textarea:focus-visible {
   outline-offset: 2px;
 }
 
+.app-select {
+  position: relative;
+  width: 100%;
+  min-width: 0;
+}
+
+.app-select-trigger {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 18px;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-width: 0;
+  height: 40px;
+  padding: 0 10px 0 12px;
+  border: 1px solid var(--theme-d5d2cb);
+  border-radius: 8px;
+  background: var(--theme-ffffff);
+  color: var(--theme-2d2a26);
+  text-align: left;
+  transition: border-color 140ms ease, background 140ms ease, box-shadow 140ms ease;
+}
+
+.app-select-trigger:hover:not(:disabled) {
+  border-color: var(--theme-aaa49b);
+  background: var(--theme-fffdf8);
+}
+
+.app-select-trigger:focus-visible,
+.app-select.open .app-select-trigger {
+  border-color: var(--ui-accent);
+  outline: 0;
+  box-shadow: 0 0 0 3px var(--ui-focus-ring);
+}
+
+.app-select-trigger:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+}
+
+.app-select-value {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.app-select-trigger > svg {
+  color: var(--theme-7a746c);
+  transition: transform 160ms ease;
+}
+
+.app-select.open .app-select-trigger > svg {
+  transform: rotate(180deg);
+}
+
+.app-select-menu {
+  position: absolute;
+  z-index: 120;
+  top: calc(100% + 6px);
+  left: 0;
+  display: grid;
+  gap: 2px;
+  width: 100%;
+  min-width: 0;
+  max-height: min(280px, calc(100vh - 32px));
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 6px;
+  border: 1px solid var(--theme-d5d2cb);
+  border-radius: 10px;
+  background: var(--theme-ffffff);
+  box-shadow: 0 16px 38px rgba(45, 42, 38, 0.18), 0 3px 10px rgba(45, 42, 38, 0.08);
+  animation: app-select-menu-in 120ms ease-out;
+}
+
+.app-select.open-upward .app-select-menu {
+  top: auto;
+  bottom: calc(100% + 6px);
+  transform-origin: bottom;
+}
+
+.app-select-option {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 18px;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 36px;
+  padding: 7px 9px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--theme-433f39);
+  font-size: var(--font-size-body);
+  text-align: left;
+}
+
+.app-select-option > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.app-select-option.highlighted {
+  background: var(--theme-f4f1ea);
+}
+
+.app-select-option.selected {
+  background: var(--ui-accent-soft);
+  color: var(--ui-accent-strong);
+  font-weight: 700;
+}
+
+.app-select-option.selected.highlighted {
+  box-shadow: inset 0 0 0 1px var(--ui-accent);
+}
+
+.app-select-option > svg {
+  color: var(--ui-accent-strong);
+}
+
+.app-select-option:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+@keyframes app-select-menu-in {
+  from {
+    opacity: 0;
+    transform: translateY(-3px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.app-select.open-upward .app-select-menu {
+  animation-name: app-select-menu-in-upward;
+}
+
+@keyframes app-select-menu-in-upward {
+  from {
+    opacity: 0;
+    transform: translateY(3px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
 .app-shell {
   display: grid;
   grid-template-columns: 264px minmax(0, 1fr);
@@ -2529,7 +2683,7 @@ textarea:focus-visible {
   flex: none;
 }
 
-.config-software-select .config-network-input {
+.config-software-select .app-select-trigger {
   height: 42px;
 }
 
@@ -4023,7 +4177,7 @@ textarea:focus-visible {
   background: var(--theme-fffdf8);
 }
 
-.provider-cloak-settings select {
+.provider-cloak-settings .app-select-trigger {
   width: 100%;
   min-width: 0;
   height: 40px;
@@ -6059,7 +6213,7 @@ textarea:focus-visible {
   padding: 10px;
 }
 
-.usage-filter-panel select,
+.usage-filter-panel .app-select-trigger,
 .usage-filter-panel input {
   min-width: 0;
   height: 36px;
@@ -6607,7 +6761,7 @@ textarea:focus-visible {
   min-height: 42px;
 }
 
-.auth-files-toolbar select {
+.auth-files-toolbar .app-select-trigger {
   width: 100%;
   height: 38px;
   border: 0;
@@ -7512,16 +7666,12 @@ textarea:focus-visible {
     grid-template-columns: 18px minmax(0, 1fr);
   }
 
-  .auth-files-toolbar select {
+  .auth-files-toolbar .app-select-trigger {
     border-top: 1px solid var(--theme-e3e1db);
     border-left: 0;
   }
 
-  .auth-files-toolbar select:first-of-type {
-    grid-column: 1 / -1;
-  }
-
-  .auth-files-toolbar select:last-of-type {
+  .auth-files-toolbar > .app-select {
     grid-column: 1 / -1;
   }
 

--- a/tests/appSelect.test.ts
+++ b/tests/appSelect.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'bun:test';
+import { nextEnabledOptionIndex, type AppSelectOption } from '../src/components/AppSelect';
+
+const options: AppSelectOption[] = [
+  { value: 'first', label: 'First' },
+  { value: 'disabled', label: 'Disabled', disabled: true },
+  { value: 'last', label: 'Last' },
+];
+
+describe('custom select keyboard navigation', () => {
+  it('skips disabled options in both directions', () => {
+    expect(nextEnabledOptionIndex(options, 0, 1)).toBe(2);
+    expect(nextEnabledOptionIndex(options, 2, -1)).toBe(0);
+  });
+
+  it('wraps at both ends', () => {
+    expect(nextEnabledOptionIndex(options, 2, 1)).toBe(0);
+    expect(nextEnabledOptionIndex(options, 0, -1)).toBe(2);
+  });
+
+  it('handles empty and fully disabled menus', () => {
+    expect(nextEnabledOptionIndex([], -1, 1)).toBe(-1);
+    expect(nextEnabledOptionIndex([{ value: 'x', label: 'X', disabled: true }], -1, 1)).toBe(-1);
+  });
+});


### PR DESCRIPTION
## Summary
- replace all 10 native select elements with a shared themed dropdown component
- add selected-state checkmarks, responsive upward placement, and consistent light/dark styling
- support keyboard navigation, disabled items, click-outside closing, and accessible listbox semantics

## Validation
- `bun run check`
- `bun test` (114 passed)
- `bun run build`