### PR TITLE
fix(agent): inject discovered PATH into agent subcommands

### DIFF
--- a/src-tauri/src/agents/discovery.rs
+++ b/src-tauri/src/agents/discovery.rs
@@ -558,7 +558,11 @@ pub(crate) fn uninstall_pi_provider_inner(
         Vec::new(),
     ))
 }
-
+pub(crate) fn configure_agent_command_environment(command: &mut Command, home: &Path) {
+  if let Ok(joined_path) = env::join_paths(agent_executable_directories(home)) {
+      command.env("PATH", joined_path);
+  }
+}
 pub(crate) fn install_pi_package(
     executable: &Path,
     home: &Path,
@@ -576,6 +580,7 @@ pub(crate) fn install_pi_package(
         .stdin(Stdio::null());
     configure_background_command(&mut command);
     configure_networked_command(&mut command, proxy_url);
+    configure_agent_command_environment(&mut command, home);
     let output = command
         .output()
         .map_err(|error| format!("执行 Pi 插件安装失败: {error}"))?;
@@ -613,6 +618,7 @@ pub(crate) fn update_pi_package(
         .stdin(Stdio::null());
     configure_background_command(&mut command);
     configure_networked_command(&mut command, proxy_url);
+    configure_agent_command_environment(&mut command, home);
     let output = command
         .output()
         .map_err(|error| format!("执行 Pi 插件更新失败: {error}"))?;
@@ -644,6 +650,7 @@ pub(crate) fn remove_pi_package(executable: &Path, home: &Path) -> Result<(), St
         .current_dir(home)
         .stdin(Stdio::null());
     configure_background_command(&mut command);
+    configure_agent_command_environment(&mut command, home);
     let output = command
         .output()
         .map_err(|error| format!("鎵ц Pi 鎻掍欢鍗歌浇澶辫触: {error}"))?;


### PR DESCRIPTION
 ### 修复问题 / Problem
  在 macOS 上作为 GUI 应用运行时，子进程仅继承系统默认的极简
  `PATH`（`/usr/bin:/bin:/usr/sbin:/sbin`），不包含
  Homebrew（`/opt/homebrew/bin`）等常见环境路径。

  虽然 `find_pi_executable` 能通过 `agent_executable_directories` 正确找到 `pi`
  可执行文件，但在执行 `install_pi_package` 等命令时：
  1. `pi` 脚本 shebang（`#!/usr/bin/env node`）因找不到 `node` 报错：`env: node: No such file or directory`。
  2. `pi` 内部通过 `child_process` 调用 `npm` 时报错：`spawn npm ENOENT`。

  ### 解决方案 / Solution
  在执行 agent 相关子进程（如 `pi install / update / remove`）时，通过
  `env::join_paths(agent_executable_directories(home))` 将应用已发现的可执行文件目录注入到
  `Command` 的 `PATH` 环境变量中，确保子进程及其下游工具（node/npm 等）能够正常运行。