### PR TITLE
docs: add WebBrain to related projects

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -145,3 +145,4 @@ GitHub Actions では、次のリリースパッケージをビルドします�
 ## 関連プロジェクト
 
 - [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) — 本アプリケーションが管理するプロキシコアです。
+- [WebBrain](https://github.com/webbrain-one/webbrain) — EasyCLIProxyAPI のローカル OpenAI 互換エンドポイントに接続できるブラウザーエージェントです。[セットアップ、セキュリティ、アカウントリスクのガイド](https://webbrain.one/docs/easy-cli-proxy/)をご覧ください。

--- a/README.md
+++ b/README.md
@@ -157,3 +157,4 @@ GitHub Actions builds the following release packages:
 ## Related Project
 
 - [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) — the proxy core managed by this application.
+- [WebBrain](https://github.com/webbrain-one/webbrain) — a browser agent that can connect to EasyCLIProxyAPI's local OpenAI-compatible endpoint. See the [setup, security, and account-risk guide](https://webbrain.one/docs/easy-cli-proxy/).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -150,3 +150,4 @@ GitHub Actions 会构建以下发行包：
 ## 相关项目
 
 - [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) — 本软件负责管理的代理内核。
+- [WebBrain](https://github.com/webbrain-one/webbrain) — 可连接 EasyCLIProxyAPI 本地 OpenAI 兼容端点的浏览器智能体。请参阅[设置、安全与账号风险指南](https://webbrain.one/docs/zh/easy-cli-proxy/)。


### PR DESCRIPTION
## Summary

- add WebBrain to the Related Project section in the English, Simplified Chinese, and Japanese READMEs
- WebBrain includes EasyCLIProxyAPI setup links in Settings > Providers
- link each README entry to WebBrain's setup guide, with the localized guide used in the Chinese README

## Links

- [WebBrain](https://webbrain.one/)
- [EasyCLIProxyAPI setup guide](https://webbrain.one/docs/easy-cli-proxy/)
- [Chinese setup guide](https://webbrain.one/docs/zh/easy-cli-proxy/)

## Validation

- verified the WebBrain repository and both guide URLs return HTTP 200
- ran `git diff --check`
- documentation-only change
