### PR TITLE
build(linux): build on ubuntu-22.04 so portable binaries don't require glibc 2.39

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,12 +64,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: ubuntu-24.04
+          # Build on the oldest supported Ubuntu release so the portable binary
+          # does not require a newer glibc than Ubuntu 22.04 provides.
+          - runner: ubuntu-22.04
             os: linux
             display_os: Linux
             arch: amd64
             suffix: tar.gz
-          - runner: ubuntu-24.04-arm
+          - runner: ubuntu-22.04-arm
             os: linux
             display_os: Linux
             arch: aarch64
@@ -136,7 +138,17 @@ jobs:
         if: matrix.os == 'linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y \
+            build-essential \
+            curl \
+            file \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            patchelf \
+            wget
       - name: Build GUI
         env:
           GITCODE_GUI_REPOSITORY: ${{ vars.GITCODE_GUI_REPOSITORY }}


### PR DESCRIPTION
## Problem

Linux release artifacts are built on the `ubuntu-24.04` runner (glibc 2.39), and the GUI binary ends up requiring `GLIBC_2.39` symbols (`pidfd_spawnp`, `pidfd_getpid`). On older but still mainstream distros the binary fails to start:

```
$ ./EasyCLIProxyAPI --version   # Ubuntu 22.04 (glibc 2.35)
./EasyCLIProxyAPI: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by ./EasyCLIProxyAPI)
```

Affected distros include Ubuntu 22.04 LTS (glibc 2.35) and Debian 12 (glibc 2.36) — i.e. anything with glibc < 2.39.

## Change

- Build the Linux targets on `ubuntu-22.04` / `ubuntu-22.04-arm` (the oldest supported runners → lowest glibc requirement for the portable binaries).
- Update the Linux apt dependency list to match the Tauri v2 Linux prerequisites: replace `libappindicator3-dev` with `libayatana-appindicator3-dev`, and add `build-essential`, `curl`, `file`, `libssl-dev`, `libxdo-dev`, `wget`.

Closes #216.

## Verification

Built from this branch in my fork ([run 33857630437](https://github.com/yangtzech/EasyCLIProxyAPI/actions/runs/33857630437)): the `linux-amd64` and `linux-aarch64` jobs pass and produce artifacts. (The darwin jobs in that run failed only because my fork does not have the Apple signing secrets — unrelated to this change.)

glibc symbol requirements, compared via `objdump -T`:

| Binary | Highest GLIBC version required | Runs on Ubuntu 22.04 (glibc 2.35)? |
| --- | --- | --- |
| v0.2.74 release (built on 24.04) | GLIBC_2.39 | ❌ |
| This change (built on 22.04) | GLIBC_2.34 | ✅ |

The rebuilt binary starts fine on a glibc 2.35 host.

## Notes

- macOS / Windows build steps are untouched.
- If GitHub eventually retires the ubuntu-22.04 runner image, an alternative is building inside a 22.04 container to keep the same glibc floor.
